### PR TITLE
Allow to monitor all changes in repositories of an user

### DIFF
--- a/server.py
+++ b/server.py
@@ -101,11 +101,16 @@ def get_hook_info(data):
         repo = data['repository']['full_name']
         if repo in config.MATTERMOST_WEBHOOK_URLS:
             return config.MATTERMOST_WEBHOOK_URLS[repo]
-    if 'organization' in data:
+    elif 'organization' in data:
         org = data['organization']['login']
         if org in config.MATTERMOST_WEBHOOK_URLS:
             return config.MATTERMOST_WEBHOOK_URLS[org]
-    return config.MATTERMOST_WEBHOOK_URLS['default']
+    elif 'repository' in data:
+        owner = data['repository']['owner']['login']
+        if owner in config.MATTERMOST_WEBHOOK_URLS:
+            return config.MATTERMOST_WEBHOOK_URLS[owner]
+    else:
+        return config.MATTERMOST_WEBHOOK_URLS['default']
 
 if __name__ == "__main__":
     port = int(os.environ.get('PORT', 5000))

--- a/server.py
+++ b/server.py
@@ -101,16 +101,21 @@ def get_hook_info(data):
         repo = data['repository']['full_name']
         if repo in config.MATTERMOST_WEBHOOK_URLS:
             return config.MATTERMOST_WEBHOOK_URLS[repo]
-    elif 'organization' in data:
+    if 'organization' in data:
         org = data['organization']['login']
         if org in config.MATTERMOST_WEBHOOK_URLS:
             return config.MATTERMOST_WEBHOOK_URLS[org]
-    elif 'repository' in data:
-        owner = data['repository']['owner']['login']
-        if owner in config.MATTERMOST_WEBHOOK_URLS:
-            return config.MATTERMOST_WEBHOOK_URLS[owner]
-    else:
-        return config.MATTERMOST_WEBHOOK_URLS['default']
+    if 'repository' in data:
+        if 'login' in data['repository']['owner']:
+            owner = data['repository']['owner']['login']
+            if owner in config.MATTERMOST_WEBHOOK_URLS:
+                return config.MATTERMOST_WEBHOOK_URLS[owner]
+        if 'name' in data['repository']['owner']:
+            owner = data['repository']['owner']['name']
+            if owner in config.MATTERMOST_WEBHOOK_URLS:
+                return config.MATTERMOST_WEBHOOK_URLS[owner]
+    return config.MATTERMOST_WEBHOOK_URLS['default']
+
 
 if __name__ == "__main__":
     port = int(os.environ.get('PORT', 5000))


### PR DESCRIPTION
Dear guys, thank you very much for your helpful Github integration. However, I would propose a small function extension:

# Current status
If I want to monitor the repositories of an user, I have to define each user repository as a single line in the config.py file. If one has lots of repositories this is quite time-consuming.

# Updated version
I can still set the behaviour for each user repository individually, but if the user repository has no individual configuration. A global configuration for all repositories of an user (if defined) is used. 
Furthermore, I replaced the if statements with  elif statements which is IMHO a little bit more the python way.