### PR TITLE
Add event ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you don't want to use a secret set the field to `None`.
 
 Not all Github events are forwarded to Mattermost. Currently supported events are:
 
-* Ping, when you first added Github webhook
+* Ping events (send when first adding the Github webhook)
 * Commit pushes and comments
 * Issues (open, close, comment)
 * Pull Requests (create, merge, remove, comment)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you don't want to use a secret set the field to `None`.
 
 Not all Github events are forwarded to Mattermost. Currently supported events are:
 
+* Ping, when you first added Github webhook
 * Commit pushes and comments
 * Issues (open, close, comment)
 * Pull Requests (create, merge, remove, comment)

--- a/server.py
+++ b/server.py
@@ -31,7 +31,9 @@ def root():
     event = request.headers['X-Github-Event']
 
     msg = ""
-    if event == "pull_request":
+    if event == "ping":
+        msg = "ping from %s" % data['repository']['full_name']
+    elif event == "pull_request":
         if data['action'] == "opened":
             msg = PullRequest(data).opened()
         elif data['action'] == "closed":


### PR DESCRIPTION
This event is useful to test wether Github webhook is working or not,
just by looking at specified channel after adding webhook in github web
page.