### PR TITLE
Add an option to MATTERMOST_WEBHOOK_URLS to be able to ignore specific event actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Copy `config.template` to `config.py` and edit it with your details. For example
 USERNAME = "Github"
 ICON_URL = "yourdomain.org/github.png"
 MATTERMOST_WEBHOOK_URLS = {
-    'default' : ("yourdomain.org/hooks/hookid", "off-topic"),
+    'default' : ("yourdomain.org/hooks/hookid", "off-topic", {"issues": ["labeled"]}),
     'teamname/repositoryname' : ("yourdomain.org/hooks/hookid2", "repository-channel-id"),
     'teamname' : ("yourdomain.org/hooks/hookid3", "town-square"),
     'teamname/unimportantrepo' : None,
@@ -35,6 +35,12 @@ follows. First try to find a hook for the repositories full name.  If that
 fails, try to find a hook for the organisation name. Otherwise use the default
 hook. Repositories can be blacklisted by setting them to `None` instead of
 `(url, channel)`.
+
+Within `MATTERMOST_WEBHOOK_URLS` the value of each element must contain a hookid and
+a channel to be posted to. The third optional value in the tuple is a dictionary
+of event actions that should be ignored. This gives you more control over github events like
+'issues' which aggregates too many actions under one event. In the example above, `label`
+events are ignored, but we can still see open/close/assign events.
 
 The server is listening by default on address `0.0.0.0`, port `5000`, and
 using `/` as base route.

--- a/server.py
+++ b/server.py
@@ -85,7 +85,9 @@ def root():
             except ValueError:
                 url, channel, ignore_actions = get_hook_info(data)
 
-            if ignore_actions and data['action'] in ignore_actions:
+            if ignore_actions and \
+               data['event'] in ignore_actions and \
+               data['action'] in ignore_actions[data['event']]:
                 return "Notification action ignored (as per configuration)"
 
             post(msg, url, channel)

--- a/server.py
+++ b/server.py
@@ -1,4 +1,3 @@
-import os
 import requests
 from flask import Flask
 from flask import request
@@ -13,11 +12,12 @@ app = Flask(__name__)
 
 SECRET = hmac.new(config.SECRET, digestmod=hashlib.sha1) if config.SECRET else None
 
+
 @app.route(config.SERVER['hook'] or "/", methods=['POST'])
 def root():
     if request.json is None:
-       print 'Invalid Content-Type'
-       return 'Content-Type must be application/json and the request body must contain valid JSON', 400
+        print 'Invalid Content-Type'
+        return 'Content-Type must be application/json and the request body must contain valid JSON', 400
 
     if SECRET:
         signature = request.headers.get('X-Hub-Signature', None)
@@ -87,6 +87,7 @@ def root():
     else:
         return "Not implemented", 400
 
+
 def post(text, url, channel):
     data = {}
     data['text'] = text
@@ -99,6 +100,7 @@ def post(text, url, channel):
 
     if r.status_code is not requests.codes.ok:
         print 'Encountered error posting to Mattermost URL %s, status=%d, response_body=%s' % (url, r.status_code, r.json())
+
 
 def get_hook_info(data):
     if 'repository' in data:
@@ -123,7 +125,7 @@ def get_hook_info(data):
 
 if __name__ == "__main__":
     app.run(
-        host=config.SERVER['address'] or "0.0.0.0"
-    ,   port=config.SERVER['port'] or 5000
-    ,   debug=False
+        host=config.SERVER['address'] or "0.0.0.0",
+        port=config.SERVER['port'] or 5000,
+        debug=False
     )

--- a/server.py
+++ b/server.py
@@ -86,8 +86,8 @@ def root():
                 url, channel, ignore_actions = get_hook_info(data)
 
             if ignore_actions and \
-               data['event'] in ignore_actions and \
-               data['action'] in ignore_actions[data['event']]:
+               event in ignore_actions and \
+               data['action'] in ignore_actions[event]:
                 return "Notification action ignored (as per configuration)"
 
             post(msg, url, channel)

--- a/server.py
+++ b/server.py
@@ -79,15 +79,11 @@ def root():
     if msg:
         hook_info = get_hook_info(data)
         if hook_info:
-            ignore_actions = None
-            try:
-                url, channel = get_hook_info(data)
-            except ValueError:
-                url, channel, ignore_actions = get_hook_info(data)
+            url, channel = get_hook_info(data)
 
-            if ignore_actions and \
-               event in ignore_actions and \
-               data['action'] in ignore_actions[event]:
+            if config.GITHUB_IGNORE_ACTIONS and \
+               event in config.GITHUB_IGNORE_ACTIONS and \
+               data['action'] in config.GITHUB_IGNORE_ACTIONS[event]:
                 return "Notification action ignored (as per configuration)"
 
             post(msg, url, channel)

--- a/server.py
+++ b/server.py
@@ -79,7 +79,15 @@ def root():
     if msg:
         hook_info = get_hook_info(data)
         if hook_info:
-            url, channel = get_hook_info(data)
+            ignore_actions = None
+            try:
+                url, channel = get_hook_info(data)
+            expect ValueError:
+                url, channel, ignore_actions = get_hook_info(data)
+
+            if ignore_actions and data['action'] in ignore_actions:
+                return "Notification action ignored (as per configuration)"
+
             post(msg, url, channel)
             return "Notification successfully posted to Mattermost"
         else:

--- a/server.py
+++ b/server.py
@@ -82,7 +82,7 @@ def root():
             ignore_actions = None
             try:
                 url, channel = get_hook_info(data)
-            expect ValueError:
+            except ValueError:
                 url, channel, ignore_actions = get_hook_info(data)
 
             if ignore_actions and data['action'] in ignore_actions:


### PR DESCRIPTION
Github aggregates too many actions under some of their events. You may want to ignore `label` actions under issues, but still see issues get opened. This is an optional element to add to the tuple, so it will work whether you define it or not.