### PR TITLE
add basic support for pull request 'synchronize' action

### DIFF
--- a/mattermostgithub/payload.py
+++ b/mattermostgithub/payload.py
@@ -77,6 +77,11 @@ class PullRequest(Payload):
             action, self.number, self.title, self.url)
         return msg
 
+    def synchronize(self):
+        msg = """%s modified pull request [#%s %s](%s).""" % (self.user_link(),
+            self.number, self.title, self.url)
+        return msg
+
 class PullRequestComment(Payload):
     def __init__(self, data):
         Payload.__init__(self, data)

--- a/mattermostgithub/server.py
+++ b/mattermostgithub/server.py
@@ -41,6 +41,8 @@ def root():
             msg = PullRequest(data).closed()
         elif data['action'] == "assigned":
             msg = PullRequest(data).assigned()
+        elif data['action'] == "synchronize":
+            msg = PullRequest(data).synchronize()
     elif event == "issues":
         if data['action'] == "opened":
             msg = Issue(data).opened()


### PR DESCRIPTION
I noticed that there is no notification when a user adds a commit to a pull request. This pull request addresses that with a very trivial notification for when the "synchronize" action for pull_request is received.

The message will look like this:

> [lfbayer](https://github.com/lfbayer) modified pull request [#43 add basic support for pull request 'synchronize' action](https://github.com/softdevteam/mattermost-github-integration/pull/43)
