### PR TITLE
Fix error where python3 is not working

### DIFF
--- a/mattermostgithub/server.py
+++ b/mattermostgithub/server.py
@@ -12,7 +12,7 @@ from mattermostgithub.payload import (
 
 from mattermostgithub import app
 
-SECRET = hmac.new(config.SECRET, digestmod=hashlib.sha1) if config.SECRET else None
+SECRET = hmac.new(config.SECRET.encode('utf8'), digestmod=hashlib.sha1) if config.SECRET else None
 
 @app.route(config.SERVER['hook'] or "/", methods=['POST'])
 def root():


### PR DESCRIPTION
hmac would crash when setting a secret in python3 because it expects a bytearray the encode method does exactly that, also it works with python2