### PR TITLE
Add check for ignore ref_type

### DIFF
--- a/mattermostgithub/server.py
+++ b/mattermostgithub/server.py
@@ -86,8 +86,10 @@ def root():
 
             if hasattr(config, "GITHUB_IGNORE_ACTIONS") and \
                event in config.GITHUB_IGNORE_ACTIONS and \
-               (data['action'] in config.GITHUB_IGNORE_ACTIONS[event] \
-               or data['ref_type'] in config.GITHUB_IGNORE_ACTIONS[event]):
+               ((hasattr(data, "action") and \
+                data['action'] in config.GITHUB_IGNORE_ACTIONS[event]) \
+               or (hasattr(data, "ref_type") and \
+                   data['ref_type'] in config.GITHUB_IGNORE_ACTIONS[event])):
                 return "Notification action ignored (as per configuration)"
 
             post(msg, url, channel)

--- a/mattermostgithub/server.py
+++ b/mattermostgithub/server.py
@@ -86,7 +86,8 @@ def root():
 
             if hasattr(config, "GITHUB_IGNORE_ACTIONS") and \
                event in config.GITHUB_IGNORE_ACTIONS and \
-               data['action'] in config.GITHUB_IGNORE_ACTIONS[event]:
+               (data['action'] in config.GITHUB_IGNORE_ACTIONS[event] \
+               or data['ref_type'] in config.GITHUB_IGNORE_ACTIONS[event]):
                 return "Notification action ignored (as per configuration)"
 
             post(msg, url, channel)


### PR DESCRIPTION
If an event is create or delete data['action'] does not exist so it can not be ignored thats why another check for data['ref_type'] was necessary